### PR TITLE
Allow set encoding= in new files if a previous file used scriptencoding

### DIFF
--- a/vint/linting/policy/prohibit_abbreviation_option.py
+++ b/vint/linting/policy/prohibit_abbreviation_option.py
@@ -22,9 +22,6 @@ class ProhibitAbbreviationOption(AbstractPolicy):
     reference = ':help option-summary'
     level = Level.STYLE_PROBLEM
 
-    was_scriptencoding_found = False
-    has_encoding_opt_after_scriptencoding = False
-
 
     def listen_node_types(self):
         return [NodeType.EXCMD, NodeType.OPTION]

--- a/vint/linting/policy/prohibit_encoding_opt_after_scriptencoding.py
+++ b/vint/linting/policy/prohibit_encoding_opt_after_scriptencoding.py
@@ -12,20 +12,27 @@ class ProhibitEncodingOptionAfterScriptEncoding(AbstractPolicy):
     level = Level.WARNING
 
     was_scriptencoding_found = False
-    has_encoding_opt_after_scriptencoding = False
 
 
     def listen_node_types(self):
-        return [NodeType.EXCMD]
+        return [NodeType.EXCMD, NodeType.TOPLEVEL]
 
 
-    def is_valid(self, excmd_node, lint_context):
+    def is_valid(self, node, lint_context):
         """ Whether the specified node is valid.
 
         This policy prohibits encoding option after scriptencoding.
         """
 
-        cmd_str = excmd_node['str']
+        node_type = NodeType(node['type'])
+
+        if node_type is NodeType.TOPLEVEL:
+          self.was_scriptencoding_found = False
+          return True
+
+        assert node_type is NodeType.EXCMD
+
+        cmd_str = node['str']
 
         if re.match(r':*scripte', cmd_str):
             self.was_scriptencoding_found = True


### PR DESCRIPTION
Fixes #363 

Needs a test, but would appreciate feedback  on the approach.

Manual testing (repro case) : PASS
`tox -e py37`: PASS

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vimjas/vint/364)
<!-- Reviewable:end -->
